### PR TITLE
Update cfg-if to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/marmistrz/cvt"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if = "0.1.10"
+cfg-if = "1.0"


### PR DESCRIPTION
This will help downstream crates to avoid multiple cfg-if crates in their dependencies, now that cfg-if is actually stable (1.0)